### PR TITLE
Multi-domain configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules
 npm-debug.log
+
+#Eclipse files
+.project

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ In order to run the `redirect` application, you will need to modify the `config.
 }
 ```
 
+The "*" config is the catch all, every host not specified in the config will be redirected there.
+
 # Usage
 
 ### Starting locally

--- a/README.md
+++ b/README.md
@@ -20,8 +20,17 @@ In order to run the `redirect` application, you will need to modify the `config.
 
 ```js
 {
-  "code": 302,
-  "host": "http://pksunkara.github.com"
+  "port": 80,
+  "redirects": {
+    "localhost": {
+      "host": "http://pksunkara.github.com",
+      "code": 302
+    },
+    "*": {
+      "host": "http://www.google.com",
+      "code": 302
+    }
+  }
 }
 ```
 
@@ -31,7 +40,11 @@ In order to run the `redirect` application, you will need to modify the `config.
 
     node bin/server
 
-*Now you can visit http://localhost:3000 to be redirected*
+*Now you can visit http://localhost to be redirected*
+
+Or specify a custom port on wich to run the server:
+
+    node bin/server --port=3000
 
 # License
 

--- a/bin/server
+++ b/bin/server
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
-var config = require("nconf").loadFilesSync([__dirname+"/../config.json"]);
+var config = require("nconf")
+	.argv()
+	.file({file:__dirname+"/../config.json"});
 
-redirect = require('../lib/redirect')(config, 3000);
-console.log('redirect running on port 3000');
+redirect = require('../lib/redirect')(config.get('redirects'), config.get('port'));
+console.log('redirect running on port %d', redirect.address().port);

--- a/config.json
+++ b/config.json
@@ -1,4 +1,7 @@
 {
-	"code": 302,
-	"host": "http://pksunkara.github.com"
+	"port": 80,
+	"redirects": {
+		"host": "http://pksunkara.github.com",
+		"code": 302
+	}
 }

--- a/config.json
+++ b/config.json
@@ -1,7 +1,13 @@
 {
 	"port": 80,
 	"redirects": {
-		"host": "http://pksunkara.github.com",
-		"code": 302
+		"localhost": {
+			"host": "http://pksunkara.github.com",
+			"code": 302
+		},
+		"*": {
+			"host": "http://www.google.com",
+			"code": 302
+		}
 	}
 }

--- a/config.json
+++ b/config.json
@@ -1,13 +1,13 @@
 {
-	"port": 80,
-	"redirects": {
-		"localhost": {
-			"host": "http://pksunkara.github.com",
-			"code": 302
-		},
-		"*": {
-			"host": "http://www.google.com",
-			"code": 302
-		}
-	}
+  "port": 80,
+  "redirects": {
+    "localhost": {
+      "host": "http://pksunkara.github.com",
+      "code": 302
+    },
+    "*": {
+      "host": "http://www.google.com",
+      "code": 302
+    }
+  }
 }

--- a/lib/redirect.js
+++ b/lib/redirect.js
@@ -14,7 +14,7 @@ module.exports = function (redirects, port) {
     if(redirect){
       var url = redirect.host + req.url;
 
-      res.statusCode = redirect.code;
+      res.statusCode = redirect.code || 302;
       res.setHeader('Content-Type', 'text/plain');
       res.setHeader('Location', url);
       res.end('Redirecting to '+url);

--- a/lib/redirect.js
+++ b/lib/redirect.js
@@ -1,20 +1,9 @@
-var http = require('http')
-
-function getHostOfRequest(req){
-  var requestHost = req.headers.host;
-  if(requestHost){
-    var indexOfColon = requestHost.indexOf(':');
-    if(indexOfColon>0){
-      requestHost = requestHost.substr(0,requestHost.indexOf(':'));
-    }
-  }
-  return requestHost;
-}
+var http = require('http');
 
 // module.exports is a middleware
 module.exports = function (redirects, port) {
   return http.createServer(function (req, res) {
-    var requestHost = getHostOfRequest(req);
+    var requestHost = req.headers.host.split(':')[0];
     var redirect = redirects[requestHost];
     
     //if the host is not found in the configuration, we default to the catch all

--- a/lib/redirect.js
+++ b/lib/redirect.js
@@ -1,13 +1,40 @@
 var http = require('http')
 
+function getHostOfRequest(req){
+  var requestHost = req.headers.host;
+  if(requestHost){
+    var indexOfColon = requestHost.indexOf(':');
+    if(indexOfColon>0){
+      requestHost = requestHost.substr(0,requestHost.indexOf(':'));
+    }
+  }
+  return requestHost;
+}
+
 // module.exports is a middleware
 module.exports = function (redirects, port) {
   return http.createServer(function (req, res) {
-    var url = redirects.host + req.url;
+    var requestHost = getHostOfRequest(req);
+    var redirect = redirects[requestHost];
+    
+    //if the host is not found in the configuration, we default to the catch all
+    if(!redirect){
+      redirect = redirects['*'];
+    }
+    
+    if(redirect){
+      var url = redirect.host + req.url;
 
-    res.statusCode = redirects.code;
-    res.setHeader('Content-Type', 'text/plain');
-    res.setHeader('Location', url);
-    res.end('Redirecting to '+url);
+      res.statusCode = redirect.code;
+      res.setHeader('Content-Type', 'text/plain');
+      res.setHeader('Location', url);
+      res.end('Redirecting to '+url);
+    }else{
+    	//their is no catch all, we will just show an error message
+    	res.statusCode = 404;
+        res.setHeader('Content-Type', 'text/plain');
+        res.end('Host not found');
+    }
+    
   }).listen(port);
 }

--- a/lib/redirect.js
+++ b/lib/redirect.js
@@ -1,11 +1,11 @@
 var http = require('http')
 
 // module.exports is a middleware
-module.exports = function (config, port) {
+module.exports = function (redirects, port) {
   return http.createServer(function (req, res) {
-    var url = config.host + req.url;
+    var url = redirects.host + req.url;
 
-    res.statusCode = config.code;
+    res.statusCode = redirects.code;
     res.setHeader('Content-Type', 'text/plain');
     res.setHeader('Location', url);
     res.end('Redirecting to '+url);

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     }
   ],
   "dependencies": {
-    "nconf": "0.4.x"
+    "nconf": "0.6.x"
   },
   "devDependencies": {},
   "engines": {


### PR DESCRIPTION
I changed the configuration, so we can now specify a redirection for each requested host (vhost system). I created a catch all system if the host is not in the config file.

I also added the port in the configuration. It is now 80 by default, because it make more sense for a redirect server to use the default port. You can specify the port either in the config.json file or via the command line with "--port=3000".

And I updated the nconf version to the latest.
